### PR TITLE
Remove deprecated @SafeHtml

### DIFF
--- a/src/main/java/com/yangfan/chat/model/dao/Message.java
+++ b/src/main/java/com/yangfan/chat/model/dao/Message.java
@@ -23,7 +23,6 @@ public class Message implements Cloneable {
     private int id;
 
     @NotEmpty
-    @SafeHtml(whitelistType = SafeHtml.WhiteListType.NONE)
     @Column(length = 510, columnDefinition = "text")
     private String message;
 

--- a/src/main/java/com/yangfan/chat/model/dto/UserRegistrationDto.java
+++ b/src/main/java/com/yangfan/chat/model/dto/UserRegistrationDto.java
@@ -10,7 +10,6 @@ import javax.validation.constraints.NotBlank;
 public class UserRegistrationDto {
 
     @NotBlank
-    @SafeHtml(whitelistType = SafeHtml.WhiteListType.NONE) /* Strip all html */
     String username;
 
     @NotBlank

--- a/src/main/resources/static/js/components/about.vue
+++ b/src/main/resources/static/js/components/about.vue
@@ -23,10 +23,7 @@
                         A lot of what I use during day-to-day job is very much language/framework specific,
                         but I spent a lot of time in gaining advanced knowledge about various subjects even if they may not directly be used at work.
                         My focus is on continually challenging myself with new emerging technologies in order to build applications on them.
-                        My recent interests are in Reactor, RSocket and anything AI related subjects like LLMs (Don't fight the trend!)
-                        This project was my first attempt at building a chat-like application. Some of technologies I have incorporated in
-                        this project are Spring Websocket, Spring MVC, Spring Redis (as session storage), & Spring JPA using MySQL. Source
-                        can be found at <a href="https://github.com/YangfanCheng1/yangfan-chat" class="purple heavy">github</a>
+                        My recent interests are in Reactor, RSocket and anything AI related subjects like LLMs.
                     </p>
                     <h3>Skill Breakdown</h3>
                     <b-progress :max="max" class="mb-3">


### PR DESCRIPTION
To prevent XSS, we previously used jsoup for sanitizing input. This however is deprecated. Will look into a solution meanwhile.
```
2024-04-26 15:12:01.103 ERROR 15625 --- [boundChannel-10] .WebSocketAnnotationMethodMessageHandler : Unhandled exception from message handler method

org.springframework.messaging.MessageHandlingException: Unexpected handler method invocation error; nested exception is java.lang.NoClassDefFoundError: org/jsoup/safety/Whitelist
	at org.springframework.messaging.handler.invocation.AbstractMethodMessageHandler.handleMatch(AbstractMethodMessageHandler.java:584) [spring-messaging-5.2.7.RELEASE.jar!/:5.2.7.RELEASE]
	at org.springframework.messaging.simp.annotation.support.SimpAnnotationMethodMessageHandler.handleMatch(SimpAnnotationMethodMessageHandler.java:511) [spring-messaging-5.2.7.RELEASE.jar!/:5.2.7.RELEASE]
	at org.springframework.messaging.simp.annotation.support.SimpAnnotationMethodMessageHandler.handleMatch(SimpAnnotationMethodMessageHandler.java:94) [spring-messaging-5.2.7.RELEASE.jar!/:5.2.7.RELEASE]
	at org.springframework.messaging.handler.invocation.AbstractMethodMessageHandler.handleMessageInternal(AbstractMethodMessageHandler.java:520) [spring-messaging-5.2.7.RELEASE.jar!/:5.2.7.RELEASE]
	at org.springframework.messaging.handler.invocation.AbstractMethodMessageHandler.handleMessage(AbstractMethodMessageHandler.java:454) [spring-messaging-5.2.7.RELEASE.jar!/:5.2.7.RELEASE]
	at org.springframework.messaging.support.ExecutorSubscribableChannel$SendTask.run(ExecutorSubscribableChannel.java:144) [spring-messaging-5.2.7.RELEASE.jar!/:5.2.7.RELEASE]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_265]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_265]
	at java.lang.Thread.run(Thread.java:748) [na:1.8.0_265]
Caused by: java.lang.NoClassDefFoundError: org/jsoup/safety/Whitelist
```